### PR TITLE
[tomb-finance] New voting strategy

### DIFF
--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -112,6 +112,7 @@ import { strategy as cake } from './cake';
 import { strategy as planetFinance } from './planet-finance';
 import { strategy as impossibleFinance } from './impossible-finance';
 import { strategy as zrxVotingPower } from './zrx-voting-power';
+import { strategy as tombFinance } from './tomb-finance';
 import { strategy as trancheStakingSLICE } from './tranche-staking-slice';
 import { strategy as unipoolSameToken } from './unipool-same-token';
 
@@ -230,6 +231,7 @@ export default {
   'impossible-finance': impossibleFinance,
   badgeth,
   'zrx-voting-power': zrxVotingPower,
+  'tomb-finance': tombFinance,
   'tranche-staking-slice': trancheStakingSLICE,
   'unipool-same-token': unipoolSameToken
 };

--- a/src/strategies/tomb-finance/examples.json
+++ b/src/strategies/tomb-finance/examples.json
@@ -1,0 +1,23 @@
+[
+  {
+    "name": "Example tomb-finance query",
+    "strategy": {
+      "name": "tomb-finance",
+      "params": {
+        "vaultTokens": [
+          {
+            "symbol": "TSHARE in MLNL",
+            "address": "0x88DBF6b60c939999084e752dA7fa62fE84621193",
+            "decimals": 18
+          }
+        ]
+      }
+    },
+    "network": "250",
+    "addresses": [
+      "0x0fA5a3B6f8e26a7C2C67bd205fFcfA9f89B0e8d1",
+      "0x32439F5A7Dc35590e83AAc0a80762dE27Ab76046"
+    ],
+    "snapshot": 12368542
+  }
+]

--- a/src/strategies/tomb-finance/index.ts
+++ b/src/strategies/tomb-finance/index.ts
@@ -93,7 +93,6 @@ export async function strategy(
       const tshareInLpInWallet = parseFloat(
         formatUnits(
           result.lp[address]
-            .mul(PRECISION)
             .mul(result.lp.tshareBalance)
             .div(result.lp.totalSupply),
           18
@@ -107,7 +106,6 @@ export async function strategy(
       const tshareInCemetery = parseFloat(
         formatUnits(
           result.lpInCemetery[address].amount
-            .mul(PRECISION)
             .mul(result.lp.tshareBalance)
             .div(result.lp.totalSupply),
           18
@@ -129,6 +127,12 @@ export async function strategy(
           ),
         0
       );
+
+      console.log("tshareInWallet", tshareInWallet);
+      console.log("tshareInLpWallet", tshareInLpInWallet);
+      console.log("tshareInMasonry", tshareInMasonry);
+      console.log("tshareInCemetery", tshareInCemetery);
+      console.log("tshareInVault", tshareInVaults);
 
       return [
         address,

--- a/src/strategies/tomb-finance/index.ts
+++ b/src/strategies/tomb-finance/index.ts
@@ -128,12 +128,6 @@ export async function strategy(
         0
       );
 
-      console.log("tshareInWallet", tshareInWallet);
-      console.log("tshareInLpWallet", tshareInLpInWallet);
-      console.log("tshareInMasonry", tshareInMasonry);
-      console.log("tshareInCemetery", tshareInCemetery);
-      console.log("tshareInVault", tshareInVaults);
-
       return [
         address,
         Math.sqrt(

--- a/src/strategies/tomb-finance/index.ts
+++ b/src/strategies/tomb-finance/index.ts
@@ -113,7 +113,6 @@ export async function strategy(
 
   multi = new Multicaller(network, provider, abi, { blockTag });
 
-  multi.call(`tshare.totalSupply`, TSHARE_TOKEN_ADDRESS, 'totalSupply');
   multi.call(`lp.tshareBalance`, TSHARE_TOKEN_ADDRESS, 'balanceOf', [
     TSHARE_LP_TOKEN_ADDRESS
   ]);

--- a/src/strategies/tomb-finance/index.ts
+++ b/src/strategies/tomb-finance/index.ts
@@ -13,84 +13,10 @@ const CEMETERY_ADDRESS = '0xcc0a87F7e7c693042a9Cc703661F5060c80ACb43';
 const PRECISION = BigNumber.from(10).pow(18);
 
 const abi = [
-  {
-    inputs: [
-      {
-        internalType: 'address',
-        name: '',
-        type: 'address'
-      }
-    ],
-    name: 'balanceOf',
-    outputs: [
-      {
-        internalType: 'uint256',
-        name: 'amount',
-        type: 'uint256'
-      }
-    ],
-    stateMutability: 'view',
-    type: 'function'
-  },
-  {
-    inputs: [
-      {
-        internalType: 'uint256',
-        name: '',
-        type: 'uint256'
-      },
-      {
-        internalType: 'address',
-        name: '',
-        type: 'address'
-      }
-    ],
-    name: 'userInfo',
-    outputs: [
-      {
-        internalType: 'uint256',
-        name: 'amount',
-        type: 'uint256'
-      },
-      {
-        internalType: 'uint256',
-        name: 'rewardDebt',
-        type: 'uint256'
-      }
-    ],
-    stateMutability: 'view',
-    type: 'function'
-  },
-  {
-    constant: true,
-    inputs: [],
-    name: 'totalSupply',
-    outputs: [
-      {
-        internalType: 'uint256',
-        name: '',
-        type: 'uint256'
-      }
-    ],
-    payable: false,
-    stateMutability: 'view',
-    type: 'function'
-  },
-  {
-    constant: true,
-    inputs: [],
-    name: 'strategy',
-    outputs: [
-      {
-        internalType: 'address',
-        name: '',
-        type: 'address'
-      }
-    ],
-    payable: false,
-    stateMutability: 'view',
-    type: 'function'
-  }
+  'function balanceOf(address) view returns (uint256 amount)',
+  'function userInfo(uint256, address) view returns (uint256 amount, uint256 rewardDebt)',
+  'function totalSupply() view returns (uint256)',
+  'function strategy() view returns (address)'
 ];
 
 export async function strategy(

--- a/src/strategies/tomb-finance/index.ts
+++ b/src/strategies/tomb-finance/index.ts
@@ -1,0 +1,220 @@
+import { formatUnits } from '@ethersproject/units';
+import { BigNumber } from '@ethersproject/bignumber';
+import Multicaller from '../../utils/multicaller';
+
+export const author = 'thecryptoundertaker';
+export const version = '0.1.0';
+
+const MASONRY_ADDRESS = '0x8764DE60236C5843D9faEB1B638fbCE962773B67';
+const TSHARE_TOKEN_ADDRESS = '0x4cdF39285D7Ca8eB3f090fDA0C069ba5F4145B37';
+const TSHARE_LP_TOKEN_ADDRESS = '0x4733bc45eF91cF7CcEcaeeDb794727075fB209F2';
+const CEMETERY_ADDRESS = '0xcc0a87F7e7c693042a9Cc703661F5060c80ACb43';
+
+const PRECISION = BigNumber.from(10).pow(18);
+
+const abi = [
+  {
+    inputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address'
+      }
+    ],
+    name: 'balanceOf',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: 'amount',
+        type: 'uint256'
+      }
+    ],
+    stateMutability: 'view',
+    type: 'function'
+  },
+  {
+    inputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256'
+      },
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address'
+      }
+    ],
+    name: 'userInfo',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: 'amount',
+        type: 'uint256'
+      },
+      {
+        internalType: 'uint256',
+        name: 'rewardDebt',
+        type: 'uint256'
+      }
+    ],
+    stateMutability: 'view',
+    type: 'function'
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'totalSupply',
+    outputs: [
+      {
+        internalType: 'uint256',
+        name: '',
+        type: 'uint256'
+      }
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function'
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'strategy',
+    outputs: [
+      {
+        internalType: 'address',
+        name: '',
+        type: 'address'
+      }
+    ],
+    payable: false,
+    stateMutability: 'view',
+    type: 'function'
+  }
+];
+
+export async function strategy(
+  space,
+  network,
+  provider,
+  addresses,
+  options,
+  snapshot
+) {
+  const blockTag = typeof snapshot === 'number' ? snapshot : 'latest';
+
+  let multi = new Multicaller(network, provider, abi, { blockTag });
+
+  options.vaultTokens.forEach((token: any) => {
+    multi.call(`vaultStrategies.${token.address}`, token.address, 'strategy');
+  });
+
+  const vaultStrategiesResult = await multi.execute();
+
+  multi = new Multicaller(network, provider, abi, { blockTag });
+
+  multi.call(`tshare.totalSupply`, TSHARE_TOKEN_ADDRESS, 'totalSupply');
+  multi.call(`lp.tshareBalance`, TSHARE_TOKEN_ADDRESS, 'balanceOf', [
+    TSHARE_LP_TOKEN_ADDRESS
+  ]);
+  multi.call(`lp.totalSupply`, TSHARE_LP_TOKEN_ADDRESS, 'totalSupply');
+  options.vaultTokens.forEach((token: any) => {
+    multi.call(
+      `vaultTokens.totalSupply.${token.address}`,
+      token.address,
+      'totalSupply',
+      []
+    );
+    multi.call(
+      `vaultTokens.lpBalance.${token.address}`,
+      CEMETERY_ADDRESS,
+      'userInfo',
+      ['1', vaultStrategiesResult.vaultStrategies[token.address]]
+    );
+  });
+
+  addresses.forEach((address: any) => {
+    multi.call(`tshare.${address}`, TSHARE_TOKEN_ADDRESS, 'balanceOf', [
+      address
+    ]);
+    multi.call(`tshareInMasonry.${address}`, MASONRY_ADDRESS, 'balanceOf', [
+      address
+    ]);
+    multi.call(`lpInCemetery.${address}`, CEMETERY_ADDRESS, 'userInfo', [
+      '1',
+      address
+    ]);
+    multi.call(`lp.${address}`, TSHARE_LP_TOKEN_ADDRESS, 'balanceOf', [
+      address
+    ]);
+    options.vaultTokens.forEach((token: any) => {
+      multi.call(
+        `vaultTokens.${address}.${token.address}`,
+        token.address,
+        'balanceOf',
+        [address]
+      );
+    });
+  });
+
+  const result = await multi.execute();
+
+  return Object.fromEntries(
+    addresses.map((address: any) => {
+      const tshareInWallet = parseFloat(
+        formatUnits(result.tshare[address], 18)
+      );
+
+      const tshareInLpInWallet = parseFloat(
+        formatUnits(
+          result.lp[address]
+            .mul(PRECISION)
+            .mul(result.lp.tshareBalance)
+            .div(result.lp.totalSupply),
+          18
+        )
+      );
+
+      const tshareInMasonry = parseFloat(
+        formatUnits(result.tshareInMasonry[address], 18)
+      );
+
+      const tshareInCemetery = parseFloat(
+        formatUnits(
+          result.lpInCemetery[address].amount
+            .mul(PRECISION)
+            .mul(result.lp.tshareBalance)
+            .div(result.lp.totalSupply),
+          18
+        )
+      );
+
+      const tshareInVaults = options.vaultTokens.reduce(
+        (previous: number, token: any) =>
+          previous +
+          parseFloat(
+            formatUnits(
+              result.vaultTokens[address][token.address]
+                .mul(result.vaultTokens.lpBalance[token.address].amount)
+                .div(result.vaultTokens.totalSupply[token.address])
+                .mul(result.lp.tshareBalance)
+                .div(result.lp.totalSupply),
+              18
+            )
+          ),
+        0
+      );
+
+      return [
+        address,
+        Math.sqrt(
+          tshareInWallet +
+            tshareInLpInWallet +
+            tshareInMasonry +
+            tshareInCemetery +
+            tshareInVaults
+        )
+      ];
+    })
+  );
+}


### PR DESCRIPTION
New voting strategy for tomb.finance

Calculates the amount of TShares in:
- user's wallet
- LP in user's wallet
- LP in Cemetery TSHARE-FTM LP pool
- Masonry single-staking pool
- auto-compounding vaults of TSHARE-FTM LP

As we are using the quadratic voting, to calculate the amount of votes the `Math.sqrt()` is used on the total amount of owned Tshares.